### PR TITLE
add serialization to direction response

### DIFF
--- a/src/directions/response/directions_duration.rs
+++ b/src/directions/response/directions_duration.rs
@@ -1,17 +1,21 @@
 //! A representation of duration as a numeric value and a display string.
 
+use crate::serde::duration_to_seconds::duration_to_seconds;
 use crate::serde::seconds_to_duration::seconds_to_duration;
 use chrono::Duration;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// A representation of duration as a numeric value and a display string.
 
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Deserialize, Serialize)]
 pub struct DirectionsDuration {
     /// A string representation of the duration value.
     pub text: String,
 
     /// The duration in seconds.
-    #[serde(deserialize_with = "seconds_to_duration")]
+    #[serde(
+        deserialize_with = "seconds_to_duration",
+        serialize_with = "duration_to_seconds"
+    )]
     pub value: Duration,
 } // struct

--- a/src/directions/response/leg.rs
+++ b/src/directions/response/leg.rs
@@ -3,21 +3,19 @@
 
 use crate::{
     directions::response::{
-        directions_distance::DirectionsDistance,
-        directions_duration::DirectionsDuration,
-        step::Step,
-        transit_time::TransitTime,
+        directions_distance::DirectionsDistance, directions_duration::DirectionsDuration,
+        step::Step, transit_time::TransitTime,
     }, // crate::directions::response
     latlng::LatLng,
 }; // use crate
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// A single leg consisting of a set of steps in a DirectionsResult. Some fields
 /// in the leg may not be returned for all requests. Note that though this
 /// result is "JSON-like," it is not strictly JSON, as it directly and
 /// indirectly includes LatLng objects.
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Deserialize, Serialize)]
 pub struct Leg {
     /// An estimated arrival time for this leg. Only applicable for
     /// `TravelMode::Transit` requests.
@@ -67,7 +65,6 @@ pub struct Leg {
 } // struct
 
 impl Leg {
-
     /// A helper function for destructuring (or serializing) the optional
     /// `duration_in_traffic` field. If the `Duration` struct is populated, this
     /// function will return the _text_ field as a `String`. If the _Duration_
@@ -179,5 +176,4 @@ impl Leg {
             None => None,
         } // match
     } // fn
-
 } // impl

--- a/src/directions/response/mod.rs
+++ b/src/directions/response/mod.rs
@@ -23,18 +23,14 @@ pub mod transit_time;
 pub mod transit_vehicle;
 
 use crate::directions::{
-    response::{
-        geocoded_waypoint::GeocodedWaypoint,
-        route::Route,
-        status::Status
-    }, // crate::directions::response
+    response::{geocoded_waypoint::GeocodedWaypoint, route::Route, status::Status}, // crate::directions::response
     travel_mode::TravelMode,
 }; // use // crate::directions
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// Directions responses contain the following root elements.
 
-#[derive(Clone, Debug, PartialEq, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct Response {
     /// Contains an array of available travel modes. This field is returned when
     /// a request specifies a travel `mode` and gets no results. The array

--- a/src/directions/response/route.rs
+++ b/src/directions/response/route.rs
@@ -3,20 +3,18 @@
 use crate::{
     bounds::Bounds,
     directions::response::{
-        leg::Leg,
-        overview_polyline::OverviewPolyline,
-        transit_fare::TransitFare,
+        leg::Leg, overview_polyline::OverviewPolyline, transit_fare::TransitFare,
     }, // crate::directions::response
 }; // use
 use rust_decimal::Decimal;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// A single route containing a set of legs in a
 /// [Response](https://developers.google.com/maps/documentation/javascript/reference/directions#DirectionsResult).
 /// Note that though this object is "JSON-like," it is not strictly JSON, as it
 /// directly and indirectly includes `LatLng` objects.
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Deserialize, Serialize)]
 pub struct Route {
     /// The bounds for this route.
     pub bounds: Bounds,
@@ -73,7 +71,6 @@ pub struct Route {
 } // struct
 
 impl Route {
-
     /// A helper function for destructuring (or serializing) the `summary`
     /// field. If the _summary_ text is populated, this function will return the
     /// _summary_ text in the `String` format. If the _summary_ text is empty,
@@ -171,5 +168,4 @@ impl Route {
             ))
         } // if
     } // fn
-
 } // impl

--- a/src/directions/response/step.rs
+++ b/src/directions/response/step.rs
@@ -4,17 +4,14 @@
 use crate::{
     directions::{
         response::{
-            directions_distance::DirectionsDistance,
-            directions_duration::DirectionsDuration,
-            driving_maneuver::DrivingManeuver,
-            polyline::Polyline,
-            transit_details::TransitDetails,
+            directions_distance::DirectionsDistance, directions_duration::DirectionsDuration,
+            driving_maneuver::DrivingManeuver, polyline::Polyline, transit_details::TransitDetails,
         }, // crate::directions::response
         travel_mode::TravelMode,
     }, // crate::directions
     latlng::LatLng,
 }; // use crate
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// Each element in the `steps` array defines a single step of the calculated
 /// directions. A step is the most atomic unit of a direction's route,
@@ -37,7 +34,7 @@ use serde::Deserialize;
 /// in the inner steps array, such as: "Head north-west", "Turn left onto
 /// Arelious Walker", and "Turn left onto Innes Ave".
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Deserialize, Serialize)]
 pub struct Step {
     /// The distance covered by this step. This property may be undefined as the
     /// distance may be unknown.
@@ -77,7 +74,6 @@ pub struct Step {
 } // struct
 
 impl Step {
-
     /// A helper function for destructuring (or serializing) the optional
     /// `maneuver` field. If the `ManeuverType` enum in the step is populated,
     /// this function will return it as a `String`. If the _ManeuverType_ enum
@@ -92,5 +88,4 @@ impl Step {
             None => None,
         } // match
     } // fn
-
 } // impl

--- a/src/serde/duration_to_seconds.rs
+++ b/src/serde/duration_to_seconds.rs
@@ -1,0 +1,13 @@
+//! Contains Serde serializer/deserializer for converting a quantity of seconds
+//! in `time::Duration` struct into `String` format.
+
+use chrono::Duration;
+use serde::Serializer;
+
+pub fn duration_to_seconds<S>(data: &Duration, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let seconds = data.num_seconds();
+    serializer.serialize_i64(seconds)
+}

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -1,4 +1,5 @@
 //! This module contains custom serializers and deserializers for Serde.
 
+pub mod duration_to_seconds;
 pub mod seconds_to_duration;
 //pub mod unix_to_primitivedatetime;


### PR DESCRIPTION
add possibility to serialize the Response from Direction API.  
Sometimes there is a need to cache such a responses in order to reuse instead making direct request to google api. 