### PR TITLE
Add cargo feature for enabling rustls in dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+.idea/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ doctest = false
 
 [features]
 default = ["native-tls"]
-native-tls = ["reqwest/native-tls"]
+native-tls = ["reqwest/default-tls"]
 rustls = ["reqwest/rustls-tls"]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ repository = "https://github.com/leontoeides/google_maps"
 [lib]
 doctest = false
 
+[features]
+rustls-tls = ["reqwest/rustls"]
+
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
 chrono-tz = { version = "0.5", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ repository = "https://github.com/leontoeides/google_maps"
 doctest = false
 
 [features]
-rustls-tls = ["reqwest/rustls"]
+rustls = ["reqwest/rustls"]
 
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ repository = "https://github.com/leontoeides/google_maps"
 doctest = false
 
 [features]
-rustls = ["reqwest/rustls"]
+rustls = ["reqwest/rustls-tls"]
 
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ repository = "https://github.com/leontoeides/google_maps"
 doctest = false
 
 [features]
+default = ["native-tls"]
+native-tls = ["reqwest/native-tls"]
 rustls = ["reqwest/rustls-tls"]
 
 [dependencies]
@@ -25,7 +27,7 @@ log = "0.4"
 percent-encoding = "^2.1"
 rand = "0.8"
 futures = "0.3"
-reqwest = { version = "0.11", features = ["gzip"] }
+reqwest = { version = "0.11", default-features = false, features = ["gzip"] }
 rust_decimal = {version = "1.14", features = ["serde-float"] }
 rust_decimal_macros = "1.14"
 serde = { version = "1.0", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -1,9 +1,3 @@
-This is a fork of the library which uses async and non-blocking calls.
-The examples below need to be updated, by adding `.await` after `execute()`,
-and the call need to be made in an `async` function. The API should be 
-otherwise similar. (Except the rate limit has been turned off by default)
-
-
 🗺 An unofficial Google Maps Platform client library for the Rust programming
 language. This client currently implements the Directions API, Distance Matrix
 API, Elevation API, Geocoding API, and Time Zone API.
@@ -38,10 +32,12 @@ to give back to the Rust community. I hope it saves someone out there some work.
 
 # What's new?
 
-* 2.0.1: 2022-07-15: Now supports a user-configured Reqwest client in the Google
+* 2.0.2: 2021-07-16: Added support for using rustls-tls in reqwest dependency
+
+* 2.0.1: 2021-07-15: Now supports a user-configured Reqwest client in the Google
 Maps client builder. `ClientSettings::new("YOUR_API_KEY_HERE").with_reqwest_client(your_reqwest_client).finalize();`
 
-* 2.0.0: 2022-07-13: The Rust Google Maps client is now async thanks to
+* 2.0.0: 2021-07-13: The Rust Google Maps client is now async thanks to
 [seanpianka](https://github.com/seanpianka)!
 
 * 1.0.3: 2021-01-06: Updated dependencies. A few minor corrections. Async


### PR DESCRIPTION
If any downstream crates are using rustls, they will potentially have issues since the current `reqwest` dependency uses the `native-tls` default feature. This change would allow for this to be toggled.