### PR TITLE
Use serde feature of rust_decimal instead of serde-float

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ miette = "5.9"
 percent-encoding = "2.2"
 phf = { version = "0.11", features = [ "macros" ] }
 reqwest = { version = "0.11", optional = true, default-features = false }
-rust_decimal = {version = "1", features = [ "serde-float" ] }
+rust_decimal = {version = "1", features = [ "serde" ] }
 rust_decimal_macros = "1"
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"


### PR DESCRIPTION
`serde-float` forces all users of `rust_decimal` to be serialized as float instead of string when using `google_maps`.

This PR changes `rust_decimal` to only add the `serde` feature, while `serde-float` can be added externally by the using crate if desired.