### PR TITLE
Complements serialisation/deserialisation bug-fix released on 3.7.2.

### DIFF
--- a/src/directions/response/geocoder_status.rs
+++ b/src/directions/response/geocoder_status.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 /// resulting from the geocoding operation.
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all(serialize = "SCREAMING_SNAKE_CASE", deserialize = "SCREAMING_SNAKE_CASE"))]
 pub enum GeocoderStatus {
     /// Indicates that no errors occurred; the address was successfully parsed
     /// and at least one geocode was returned.


### PR DESCRIPTION
This applies the fix proposed by @leontoeides to enum GeocoderStatus. 
fix leontoeides/google_maps#30