### PR TITLE
Fix issue #32 EitherRestrictionsOrWaypoints fires in opposite case

### DIFF
--- a/src/directions/request/validate.rs
+++ b/src/directions/request/validate.rs
@@ -64,7 +64,7 @@ impl<'a> Request<'a> {
             } // if
 
             // ...restrictions cannot be set:
-            if self.restrictions.is_empty() {
+            if !self.restrictions.is_empty() {
                 return Err(Error::EitherRestrictionsOrWaypoints(
                     self.waypoints.len(),
                     self.restrictions


### PR DESCRIPTION
Adds the missing `!`

The issue currently is used if there are waypoints and there aren't restrictions. It should be used if both are present, and the comment above it and the addition of the restrictions to the issue already supported.  