### PR TITLE
Change dst_offset and raw_offset to i32

### DIFF
--- a/src/time_zone/response/mod.rs
+++ b/src/time_zone/response/mod.rs
@@ -31,7 +31,7 @@ pub struct Response {
     #[serde(rename = "dstOffset")]
     #[serde(alias = "dst_offset")]
     #[serde(default)]
-    pub dst_offset: Option<i16>,
+    pub dst_offset: Option<i32>,
 
     /// More detailed information about the reasons behind the given status
     /// code, if other than `OK`.
@@ -48,7 +48,7 @@ pub struct Response {
     #[serde(rename = "rawOffset")]
     #[serde(alias = "raw_offset")]
     #[serde(default)]
-    pub raw_offset: Option<i16>,
+    pub raw_offset: Option<i32>,
 
     /// The status of the response.
     pub status: Status,


### PR DESCRIPTION
Pacific/Auckland has a timezone offset of 43200, which is larger than an i16.