### PR TITLE
Switch from rust_decimal feature `serde-float` to `serde-with-float`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ decimal-serde-with-arbitrary-precision = ["rust_decimal/serde-with-arbitrary-pre
 miette = "7.6"
 percent-encoding = "2.3"
 phf = { version = "0.13", features = ["macros"], optional = true }
-rust_decimal = { version = "1", features = ["serde", "serde-float"] }
+rust_decimal = { version = "1", features = ["serde", "serde-with-float"] }
 rust_decimal_macros = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
This avoids changing decimal serialization behavior in projects depending on google_maps.

Fixes #39 